### PR TITLE
Add a CloudantClient connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ project and provides connectors for the services within Bluemix.
 In addition to the services supported by the Spring Cloud Connectors project the
 Bluemix Cloud Connectors project supports the following services
 
-* Cloudant - via the [Ektorp library](http://ektorp.org/)
+* Cloudant - via the supported [java-cloudant library](https://github.com/cloudant/java-cloudant) and the unsupported [Ektorp library](http://ektorp.org/)
 * SendGrid - SendGrid is already supported by the Spring Cloud Connectors project but due to
 the way the service credentials are created in VCAP_SERVICES it did not work
 * Twilio - via the [Twilio client library](https://www.twilio.com/docs/java/install)

--- a/bluemix-cloud-connectors-core/src/main/java/net/bluemix/connectors/core/creator/CloudantClientInstanceCreator.java
+++ b/bluemix-cloud-connectors-core/src/main/java/net/bluemix/connectors/core/creator/CloudantClientInstanceCreator.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright IBM Corp. 2015
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.bluemix.connectors.core.creator;
+
+import net.bluemix.connectors.core.info.CloudantServiceInfo;
+import org.springframework.cloud.service.AbstractServiceConnectorCreator;
+import org.springframework.cloud.service.ServiceConnectorConfig;
+
+import com.cloudant.client.api.ClientBuilder;
+import com.cloudant.client.api.CloudantClient;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Handles creating a CloudantClient from the CloudantServiceInfo object.
+ * @author dantwining
+ *
+ */
+public class CloudantClientInstanceCreator extends AbstractServiceConnectorCreator<CloudantClient, CloudantServiceInfo> {
+  
+  private static final Logger LOG = Logger.getLogger(CloudantClientInstanceCreator.class.getName());
+
+  @Override
+  public CloudantClient create(CloudantServiceInfo serviceInfo,
+          ServiceConnectorConfig serviceConnectorConfig) {
+    try {
+
+      URL cloudantUrl = new URL(serviceInfo.getUrl());
+
+      return ClientBuilder.url(cloudantUrl)
+              .username(serviceInfo.getUsername())
+              .password(serviceInfo.getPassword())
+              .build();
+
+    } catch (MalformedURLException e) {
+      LOG.logp(Level.WARNING, CloudantClientInstanceCreator.class.getName(), "create", "Error parsing URL", e);
+      return null;
+    }
+  }
+}
+

--- a/bluemix-cloud-connectors-core/src/main/resources/META-INF/services/org.springframework.cloud.service.ServiceConnectorCreator
+++ b/bluemix-cloud-connectors-core/src/main/resources/META-INF/services/org.springframework.cloud.service.ServiceConnectorCreator
@@ -1,3 +1,4 @@
+net.bluemix.connectors.core.creator.CloudantClientInstanceCreator
 net.bluemix.connectors.core.creator.CouchDbInstanceCreator
 net.bluemix.connectors.core.creator.TwilioRestClientCreator
 net.bluemix.connectors.core.creator.V3InstanceCreator

--- a/bluemix-cloud-connectors-core/src/test/java/net/bluemix/connectors/core/creator/CloudantClientInstanceCreatorTest.java
+++ b/bluemix-cloud-connectors-core/src/test/java/net/bluemix/connectors/core/creator/CloudantClientInstanceCreatorTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright IBM Corp. 2015
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.bluemix.connectors.core.creator;
+
+import com.cloudant.client.api.CloudantClient;
+import net.bluemix.connectors.core.info.CloudantServiceInfo;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.cloud.service.ServiceConnectorConfig;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class CloudantClientInstanceCreatorTest {
+  
+  private CloudantClientInstanceCreator creator;
+
+  @Before
+  public void setUp() throws Exception {
+    creator = new CloudantClientInstanceCreator();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    creator = null;
+  }
+
+  @Test
+  public void testCreate() {
+    CloudantServiceInfo badUrlServiceInfo = new CloudantServiceInfo("id", "username", "password", "host", 443, "url");
+    CloudantServiceInfo serviceInfo = new CloudantServiceInfo("testId", "username", "password", "username.cloudant.com", 443, 
+            "https://username:password@username.cloudant.com");
+    assertNull(creator.create(badUrlServiceInfo, new ServiceConnectorConfig(){}));
+    assertTrue(creator.create(serviceInfo, new ServiceConnectorConfig(){}) instanceof CloudantClient);
+  }
+
+}
+

--- a/pom.xml
+++ b/pom.xml
@@ -110,9 +110,31 @@
       <version>${spring.cloud.connectors.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.cloudant</groupId>
+      <artifactId>cloudant-client</artifactId>
+      <version>2.4.3</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>commons-io</artifactId>
+          <groupId>commons-io</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>org.ektorp</groupId>
       <artifactId>org.ektorp</artifactId>
       <version>1.3.0</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>commons-io</artifactId>
+          <groupId>commons-io</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.4</version>
     </dependency>
     <dependency>
       <groupId>com.twilio.sdk</groupId>

--- a/samples/java-cloudant-spring/README.md
+++ b/samples/java-cloudant-spring/README.md
@@ -1,0 +1,41 @@
+# `java-cloudant` Connector Sample with Spring Boot
+
+## About
+This is a sample demonstrating how to use the Cloudant connector in a Spring Boot application.
+The sample application stores status messages in a Cloudant DB. The sample uses the `java-cloudant` library in
+order to connect with the Cloudant DB.
+
+## Running Locally
+You can run this application locally by either pointing to Cloudant in the cloud or running CouchDB locally. (See the
+`cloudant-developer` docker image for local development).
+
+Create a file called `spring-cloud.properties` in the directory `${user.home}/.config/cloudant-connector-sample`.
+
+In the `spring-cloud.properties` file add the following properties
+
+```
+spring.cloud.appId: cloudant-sample
+spring.cloud.connectors-sample: couchdb://user:password@localhost:5984
+```
+
+You can change the `spring.cloud.connectors-sample` property to point to your own Cloudant account or local Couch DB server.
+Normally CouchDB/Cloudant URLs use the HTTP protocol, however the Bluemix Cloud Connectors project uses the protocal (in this case couchdb) to identify the connector to use for the service.  Essentially you
+can take your CouchDB/Cloudant URL and replace the http protooal with couchdb and set that as the value
+of `spring.cloud.connectors-sample`.
+
+## Running With Maven
+After you have created your `spring-cloud.properties` file run `$ mvn -P run`.
+Once the server is started navigate to [http://localhost:8080](http://localhost:8080).
+
+## Running In Eclipse
+Right click on `App.java` and select Run As -> Java Application.
+Once the server is started navigate to [http://localhost:8080](http://localhost:8080).
+
+
+## Deploying To Bluemix
+Run the following Maven profile
+```
+mvn -P deploy -Dcf.username=myusername -Dcf.password=mypassword -Dorg=bluemixOrg -Dspace=bluemixSpace
+```
+
+Replace the properties with your Bluemix username and password as well as your organization name and space.

--- a/samples/java-cloudant-spring/pom.xml
+++ b/samples/java-cloudant-spring/pom.xml
@@ -1,0 +1,185 @@
+<!--
+ * Copyright IBM Corp. 2015
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>net.bluemix.connectors.cloudant</groupId>
+  <artifactId>java-cloudant-connector-spring-sample</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  
+  <packaging>${packaging.type}</packaging>
+  
+  <!-- ====================================================================== -->
+  <!-- P A R E N T -->
+  <!-- ====================================================================== -->
+  <!-- Inherit defaults from Spring Boot -->
+ 	<parent>
+	  <groupId>org.springframework.boot</groupId>
+	  <artifactId>spring-boot-starter-parent</artifactId>
+	  <version>1.3.0.RELEASE</version>
+	  <relativePath /> <!-- lookup parent from repository -->
+	</parent>
+  
+  <!-- ====================================================================== -->
+  <!-- P R O P E R T I E S -->
+  <!-- ====================================================================== -->
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <start-class>net.bluemix.connectors.cloudant.App</start-class>
+    <java.version>1.7</java.version>
+    <packaging.type>jar</packaging.type>
+  </properties>
+
+  <!-- ====================================================================== -->
+  <!-- D E P E N D E N C I E S -->
+  <!-- ====================================================================== -->
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+	<dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-spring-service-connector</artifactId>
+    </dependency> 
+    <dependency>
+      <groupId>net.bluemix</groupId>
+      <artifactId>bluemix-cloud-connectors-cloudfoundry</artifactId>
+      <version>0.0.1-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>net.bluemix</groupId>
+      <artifactId>bluemix-cloud-connectors-local</artifactId>
+      <version>0.0.1-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
+
+  <!-- ====================================================================== -->
+  <!-- P R O F I L E S -->
+  <!-- ====================================================================== -->
+  <profiles>
+    <profile>
+      <id>deploy</id>
+      <properties>
+        <packaging.type>war</packaging.type>
+      </properties>
+      <dependencies>
+        <!-- Since we are packaging as a war when we deploy to Bluemix exclude the Tomcat dependencies, the container
+        we run in has everything we need. -->
+        <dependency>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-tomcat</artifactId>
+          <scope>provided</scope>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.cloudfoundry</groupId>
+            <artifactId>cf-maven-plugin</artifactId>
+            <version>1.0.5</version>
+            <configuration>
+              <target>https://api.ng.bluemix.net</target>
+              <appname>cloudant-connector-sample</appname>
+              <org>${org}</org>
+              <space>${space}</space>
+              <instances>1</instances>
+              <memory>512</memory>
+              <url>cloudant-connector-sample-${randomWord}.mybluemix.net</url>
+              <services>
+                <service>
+                  <name>status-db</name>
+                  <plan>Shared</plan>
+                  <label>cloudantNoSQLDB</label>
+                </service>
+              </services>
+              <env>
+                <!-- Sets the cloud profile when the app is deployed -->
+                <SPRING_PROFILES_ACTIVE>cloud</SPRING_PROFILES_ACTIVE>
+              </env>
+            </configuration>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <goals>
+                  <goal>push</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <artifactId>maven-clean-plugin</artifactId>
+            <version>2.5</version>
+            <executions>
+              <execution>
+                <id>auto-clean</id>
+                <phase>initialize</phase>
+                <goals>
+                  <goal>clean</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>run</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <artifactId>maven-clean-plugin</artifactId>
+            <version>2.5</version>
+            <executions>
+              <execution>
+                <id>auto-clean</id>
+                <phase>initialize</phase>
+                <goals>
+                  <goal>clean</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
+  <!-- ====================================================================== -->
+  <!-- B U I L D -->
+  <!-- ====================================================================== -->
+  <!-- Package as an executable jar -->
+  <build>
+    <defaultGoal>package</defaultGoal>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/samples/java-cloudant-spring/src/main/java/net/bluemix/connectors/cloudant/App.java
+++ b/samples/java-cloudant-spring/src/main/java/net/bluemix/connectors/cloudant/App.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright IBM Corp. 2014
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.bluemix.connectors.cloudant;
+
+import com.cloudant.client.api.CloudantClient;
+import com.cloudant.client.api.Database;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.context.embedded.ConfigurableEmbeddedServletContainer;
+import org.springframework.boot.context.embedded.EmbeddedServletContainerCustomizer;
+import org.springframework.boot.context.embedded.MimeMappings;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ComponentScan
+@EnableAutoConfiguration
+public class App implements EmbeddedServletContainerCustomizer {
+
+  public static void main(String[] args) throws Exception {
+      SpringApplication.run(App.class, args);
+  }
+
+  @Override
+  public void customize(ConfigurableEmbeddedServletContainer container) {
+    //Enabled UTF-8 as the default character encoding for static HTML resources.
+    //If you would like to disable this comment out the 3 lines below or change
+    //the encoding to whatever you would like.
+    MimeMappings mappings = new MimeMappings(MimeMappings.DEFAULT);
+    mappings.add("html", "text/html;charset=utf-8");
+    container.setMimeMappings(mappings );
+  }
+
+  @Bean
+  public Database statusDatabase(CloudantClient client) {
+    return client.database("status", true);
+  }
+
+}

--- a/samples/java-cloudant-spring/src/main/java/net/bluemix/connectors/cloudant/Status.java
+++ b/samples/java-cloudant-spring/src/main/java/net/bluemix/connectors/cloudant/Status.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright IBM Corp. 2014
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.bluemix.connectors.cloudant;
+
+import org.codehaus.jackson.annotate.JsonWriteNullProperties;
+
+@JsonWriteNullProperties(false)
+public class Status {
+  private String _id;
+  private String _rev;
+  private String msg;
+  public String getId() {
+    return _id;
+  }
+  public void setId(String id) {
+    this._id = id;
+  }
+  public String getMsg() {
+    return msg;
+  }
+  public void setMsg(String msg) {
+    this.msg = msg;
+  }
+  public String getRevision() {
+    return _rev;
+  }
+}
+

--- a/samples/java-cloudant-spring/src/main/java/net/bluemix/connectors/cloudant/StatusRepository.java
+++ b/samples/java-cloudant-spring/src/main/java/net/bluemix/connectors/cloudant/StatusRepository.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright IBM Corp. 2014
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.bluemix.connectors.cloudant;
+
+import com.cloudant.client.api.Database;
+import com.cloudant.client.api.model.Response;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+public class StatusRepository {
+
+  @Autowired
+  private Database db;
+
+  public void add(Status status) {
+    Response response = db.post(status);
+    status.setId(response.getId());
+  }
+
+  public Status get(String id) {
+    return db.find(Status.class, id);
+  }
+
+  public void remove(String id, String revision) {
+    db.remove(id, revision);
+  }
+
+  public void update(Status update) {
+    db.update(update);
+  }
+
+  public List<Status> getAll() {
+    try {
+      return db.getAllDocsRequestBuilder().includeDocs(true).build().getResponse().getDocsAs(Status.class);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}
+

--- a/samples/java-cloudant-spring/src/main/java/net/bluemix/connectors/cloudant/StatusRestController.java
+++ b/samples/java-cloudant-spring/src/main/java/net/bluemix/connectors/cloudant/StatusRestController.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright IBM Corp. 2014
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.bluemix.connectors.cloudant;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/status")
+public class StatusRestController {
+
+  @Autowired
+  private StatusRepository repo;
+
+  @RequestMapping(method=RequestMethod.GET)
+  public List<Status> getAll() {
+    return repo.getAll();
+  }
+  
+  @RequestMapping(method=RequestMethod.POST)
+  public Status create(@RequestBody Status status) {
+    repo.add(status);
+    return status;
+  }
+  
+  @RequestMapping(method=RequestMethod.DELETE, value="{id}")
+  public void delete(@PathVariable String id) {
+    final Status status = repo.get(id);
+    repo.remove(id, status.getRevision());
+  }
+  
+  @RequestMapping(method=RequestMethod.PUT, value="{id}")
+  public Status update(@RequestBody Status status, @PathVariable String id) {
+    Status update = repo.get(id);
+    update.setMsg(status.getMsg());
+    repo.update(update);
+    return update;
+  }
+}
+

--- a/samples/java-cloudant-spring/src/main/java/net/bluemix/connectors/cloudant/config/Config.java
+++ b/samples/java-cloudant-spring/src/main/java/net/bluemix/connectors/cloudant/config/Config.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright IBM Corp. 2014
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.bluemix.connectors.cloudant.config;
+
+import com.cloudant.client.api.CloudantClient;
+import org.springframework.cloud.config.java.AbstractCloudConfig;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+
+public class Config {
+  @Configuration
+  static class CloudConfiguration extends AbstractCloudConfig {
+    @Bean
+    public CloudantClient cloudantClient() {
+      CloudantClient instance = connectionFactory().service(CloudantClient.class);
+      return instance;
+    }
+  }
+}

--- a/samples/java-cloudant-spring/src/main/resources/application.properties
+++ b/samples/java-cloudant-spring/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+# Add Spring configuration properties to this file

--- a/samples/java-cloudant-spring/src/main/resources/spring-cloud-bootstrap.properties
+++ b/samples/java-cloudant-spring/src/main/resources/spring-cloud-bootstrap.properties
@@ -1,0 +1,1 @@
+spring.cloud.propertiesFile: ${user.home}/.config/cloudant-connector-sample/spring-cloud.properties

--- a/samples/java-cloudant-spring/src/main/resources/static/css/jumbotron-narrow.css
+++ b/samples/java-cloudant-spring/src/main/resources/static/css/jumbotron-narrow.css
@@ -1,0 +1,94 @@
+/*
+ * Copyright IBM Corp. 2014
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* Space out content a bit */
+body {
+  padding-top: 20px;
+  padding-bottom: 20px;
+}
+
+/* Everything but the jumbotron gets side spacing for mobile first views */
+.header,
+.marketing,
+.footer {
+  padding-right: 15px;
+  padding-left: 15px;
+}
+
+/* Custom page header */
+.header {
+  border-bottom: 1px solid #e5e5e5;
+}
+/* Make the masthead heading the same height as the navigation */
+.header h3 {
+  padding-bottom: 19px;
+  margin-top: 0;
+  margin-bottom: 0;
+  line-height: 40px;
+}
+
+/* Custom page footer */
+.footer {
+  padding-top: 19px;
+  color: #777;
+  border-top: 1px solid #e5e5e5;
+}
+
+/* Customize container */
+@media (min-width: 768px) {
+  .container {
+    max-width: 730px;
+  }
+}
+.container-narrow > hr {
+  margin: 30px 0;
+}
+
+/* Main marketing message and sign up button */
+.jumbotron {
+  text-align: center;
+  border-bottom: 1px solid #e5e5e5;
+}
+.jumbotron .btn {
+  padding: 14px 24px;
+  font-size: 21px;
+}
+
+/* Supporting marketing content */
+.marketing {
+  margin: 40px 0;
+}
+.marketing p + h4 {
+  margin-top: 28px;
+}
+
+/* Responsive: Portrait tablets and up */
+@media screen and (min-width: 768px) {
+  /* Remove the padding we set earlier */
+  .header,
+  .marketing,
+  .footer {
+    padding-right: 0;
+    padding-left: 0;
+  }
+  /* Space out the masthead */
+  .header {
+    margin-bottom: 30px;
+  }
+  /* Remove the bottom border on the jumbotron for visual effect */
+  .jumbotron {
+    border-bottom: 0;
+  }
+}

--- a/samples/java-cloudant-spring/src/main/resources/static/index.html
+++ b/samples/java-cloudant-spring/src/main/resources/static/index.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<!--
+ * Copyright IBM Corp. 2014
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+-->
+<html lang="en" ng-app="cloudantApp">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="">
+    <meta name="author" content="">
+    <link rel="icon" href="../../favicon.ico">
+    <style type="text/css">
+      .status-table .glyphicon {
+        cursor: pointer;
+      }
+    </style>
+
+    <title>Cloudant Connector</title>
+
+    <!-- Bootstrap core CSS -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
+
+    <!-- Custom styles for this template -->
+    <link href="css/jumbotron-narrow.css" rel="stylesheet">
+
+    <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
+    <!--[if lt IE 9]>
+      <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
+      <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+    <![endif]-->
+  </head>
+
+  <body>
+
+    <div class="container">
+      <div class="header">
+        <ul class="nav nav-pills pull-right">
+          <li class="active"><a href="#">Home</a></li>
+        </ul>
+        <h3 class="text-muted">Cloudant Connector</h3>
+      </div>
+
+      <div class="jumbotron">
+        <h1>Sample</h1>
+        <p class="lead">Sample demonstrating how to use the Cloudant connector.</p>
+      </div>
+      
+      <div ng-view></div>
+
+      <div class="footer">
+        <p>&copy; Company 2014</p>
+      </div>
+
+    </div> <!-- /container -->
+
+
+    <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular-route.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular-resource.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular-ui-bootstrap/0.11.0/ui-bootstrap.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular-ui-bootstrap/0.11.0/ui-bootstrap-tpls.min.js"></script>
+    <script type="text/javascript" src="js/app.js"></script>
+    <script type="text/javascript" src="js/status/status.js"></script>
+    <script type="text/javascript" src="js/service.js"></script>
+  </body>
+</html>

--- a/samples/java-cloudant-spring/src/main/resources/static/js/app.js
+++ b/samples/java-cloudant-spring/src/main/resources/static/js/app.js
@@ -1,0 +1,16 @@
+/*
+ * Copyright IBM Corp. 2014
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+angular.module('cloudantApp', ['ngRoute', 'cloudantApp.status']);

--- a/samples/java-cloudant-spring/src/main/resources/static/js/service.js
+++ b/samples/java-cloudant-spring/src/main/resources/static/js/service.js
@@ -1,0 +1,20 @@
+/*
+ * Copyright IBM Corp. 2014
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+var services = angular.module('cloudantApp.services', ['ngResource']);
+
+services.factory('StatusService', function($resource) {
+  return $resource('/api/status/:id', {id : "@id"});
+});

--- a/samples/java-cloudant-spring/src/main/resources/static/js/status/status.html
+++ b/samples/java-cloudant-spring/src/main/resources/static/js/status/status.html
@@ -1,0 +1,16 @@
+<div class="input-group input-group-lg">
+  <input type="text" class="form-control" ng-model="status.msg" placeholder="Status">
+  <span class="input-group-btn">
+    <button class="btn btn-default" type="button" ng-click="submit()">Add</button>
+  </span>
+</div>
+<br/>
+<div class="alert alert-info" ng-show="statuses.length == 0">
+  <p>There are currently no questions, the page will update automatically as new questions come in.</p>
+</div>
+<table class="table table-hover status-table">
+  <tr ng-repeat="status in statuses">
+    <td style="width: 100%">{{status.msg}}</td>
+  	<td><span class="glyphicon glyphicon-trash" ng-click="delete(status, $index)"></span><td>
+   <tr>
+</table> 

--- a/samples/java-cloudant-spring/src/main/resources/static/js/status/status.js
+++ b/samples/java-cloudant-spring/src/main/resources/static/js/status/status.js
@@ -1,0 +1,42 @@
+/*
+ * Copyright IBM Corp. 2014
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+angular.module('cloudantApp.status', ['cloudantApp.services'])
+.config(['$routeProvider', function ($routeProvider) {
+  $routeProvider.otherwise({
+    templateUrl: 'js/status/status.html',
+    controller: 'StatusController'
+  });
+}])
+.controller('StatusController', ['$scope', 'StatusService', function($scope, StatusService) {
+  $scope.status = {};
+  $scope.statuses = StatusService.query();
+  $scope.submit = function() {
+	StatusService.save($scope.status).$promise.then(function(savedStatus) {
+	  $scope.statuses.push(savedStatus);
+	  $scope.status.msg = '';
+	}, function(err) {
+	  console.error(err);
+	});  
+  };
+  
+  $scope.delete = function(status, index) {
+    StatusService.delete({id:status.id}).$promise.then(function() {
+      $scope.statuses.splice(index, 1);  
+    }, function(err) {
+      console.error(err);
+    })
+  };
+}]);


### PR DESCRIPTION
The CloudantClient from the java-cloudant library is the supported
java client for Cloudant. This change provides a CloudantClient
instance, from the java-client library, as an alternative
to the Ektorp library. In the long term, it may be worth deprecating
and/or removing the Ektorp connector.
